### PR TITLE
Configura o Endless fora da estratégia

### DIFF
--- a/aether.py
+++ b/aether.py
@@ -4,6 +4,7 @@ import math
 import time
 import numpy as np
 
+from helpers.endless import Endless
 from strategy import Athena
 from control import Zeus
 from simulator.viewer import Viewer
@@ -48,8 +49,9 @@ class Aether:
             Zeus(),
             Zeus()
         ]
-        self.athena[0].setup(3, self.field_width, self.field_height, 0.8)
-        self.athena[1].setup(3, self.field_width, self.field_height, 0.8)
+        Endless.setup(self.field_width, self.field_height)
+        self.athena[0].setup(3, 0.8)
+        self.athena[1].setup(3, 0.8)
         self.zeus[0].setup(3)
         self.zeus[1].setup(3)
 
@@ -72,7 +74,7 @@ class Aether:
 
     def loopTeam(self, team):
         while True:
-            time.sleep(0.001)
+            time.sleep(0.0000000001)
 
             if self.pause or \
                     (not self.enabled[3 * team] and not self.enabled[3 * team + 1] and not self.enabled[3 * team + 2]):

--- a/hades.py
+++ b/hades.py
@@ -32,7 +32,9 @@ class Hades(QThread):
         self.play = False
         self.isCalibrating = False
 
-        self.height = 480  # TODO pegar isso da afrodite e passar pro apolo
+        # TODO fazer com que todos os módulos utilizem esses valores
+        # esses valores devem ser pegos da interface, futuramente
+        self.height = 480
         self.width = 640
 
         self.skippedFrames = 0
@@ -60,20 +62,14 @@ class Hades(QThread):
         self.wait()
 
     def setup(self):
-        # set up apolo
+        # set up endless
+        Endless.setup(self.width, self.height)
 
         # set up athena
-        # TODO passar as dimensões corretamente
-        self.athena.setup(3, self.width, self.height, 0.6)
+        self.athena.setup(3, 0.6)
 
         # set up zeus
-        # TODO passar as dimensões corretamente
         self.zeus.setup(3)
-
-        # setting up hermes
-        # self.hermes = Hermes(self.srcXbee)
-        # invocar fly do hermes como finalização
-        # persephane deusa do submundo
 
     # LOOP PRINCIPAL
     def run(self):
@@ -96,7 +92,7 @@ class Hades(QThread):
                 velocities = self.zeusRules(commands)
                 self.hermesRules(velocities)
 
-            time.sleep(0.0001)
+            time.sleep(0.0000000001)
 
     # MAIN METHODS
 

--- a/strategy/athena.py
+++ b/strategy/athena.py
@@ -54,8 +54,7 @@ class Athena:
 
         print("Athena summoned")
 
-    def setup(self, numRobots, width, height, defaultVel):
-        Endless.setup(width, height)
+    def setup(self, numRobots, defaultVel):
         for i in range(0, numRobots):
             self.warriors.append(Warrior(defaultVel))
 


### PR DESCRIPTION
- Move o setup do Endless para o Hades
- Utiliza as variáveis de dimensão do Hades para configuração de constantes independentemente da estratégia (outros módulos não atualizados para evitar conflito)
- (Extra) Diminui o delay das threads de processamento